### PR TITLE
Fix hardware touch keys BACK/HOME/APP_SWITCH not thoroughly disabled

### DIFF
--- a/drivers/input/touchscreen/synaptics_dsx_letv/synaptics_dsx_core.c
+++ b/drivers/input/touchscreen/synaptics_dsx_letv/synaptics_dsx_core.c
@@ -1493,6 +1493,13 @@ static void synaptics_rmi4_f1a_report(struct synaptics_rmi4_data *rmi4_data,
 		do_once = 0;
 	}
 
+	if (rmi4_data->button_0d_enabled == 0) {
+	    dev_err(rmi4_data->pdev->dev.parent,
+                "%s: hw keys disabled not report\n",
+                __func__);
+	    return;
+	}
+
 	retval = synaptics_rmi4_reg_read(rmi4_data,
 			data_addr,
 			f1a->button_data_buffer,


### PR DESCRIPTION
Reproduce steps:
 1. Settings->System->Buttons->Enable on-screen nav bar: switch on
 2. Fast click navigation bar back key repeatedly(click the bottom part of nav bar that near hardware key side)
 3. APP_SWITCH Key Event will be received in framework PhoneWindowManager.java
    (by adding some logs in interceptKeyBeforeDispatching to check)
 4. APP_SWITCH UI will show on the screen

Notes:
 This bug can only be reproduced on devices that hardware nav bar
  and software nav bar keylayout in the reverse direction

Change-Id: I4447e85bd78274353b96940892e4dc3200ad53ab
Signed-off-by: zhaoguomanong <zhaoguomanong@gmail.com>